### PR TITLE
🐛 Clear sdk cache to avoid working with old data

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,2 +1,0 @@
-# Default ignored files
-/workspace.xml

--- a/assets/admin/js/setting-page.js
+++ b/assets/admin/js/setting-page.js
@@ -2,7 +2,6 @@ jQuery(function($){
 
     $("form#api-setting-form").validate({
         rules: {
-
             api_url: {
                 required: true
             },
@@ -36,13 +35,11 @@ jQuery(function($){
             company_name: {
                 required: true
             },
-            myparcel_shopid : {
+            myparcel_shopid: {
                 required: true
             }
-             
        },
        messages: {
-        
             api_url: {
                 required: "Required"
             },
@@ -75,13 +72,12 @@ jQuery(function($){
             },
             company_name: {
                 required: "Required"
-            }
+            },
             myparcel_shopid: {
                 required: "Required"
             }
-            
        },
-           
+
        // the errorPlacement has to take the table layout into account
         errorPlacement: function(error, element) {
             error.css('color','red');
@@ -92,7 +88,6 @@ jQuery(function($){
             else
                 error.appendTo( element.parent() );
         },
-    
     });
 
     setTimeout(function() {
@@ -100,5 +95,5 @@ jQuery(function($){
     }, 15000); // <-- time in milliseconds
     setTimeout(function() {
         $('#message').fadeOut('fast');
-    }, 15000); // <-- time in milliseconds    
+    }, 15000); // <-- time in milliseconds
 });

--- a/assets/front-end/js/address-checkout-page.js
+++ b/assets/front-end/js/address-checkout-page.js
@@ -4,7 +4,6 @@ jQuery(document).on('click','.different_delivery',function(){
 
 		if(jQuery(this).hasClass('myparcelcom-active')){
 
-
 			var companyName 	= jQuery.trim(jQuery(this).find('.myparcelcom-pudo-location-info .myparcelcom-pudo-location-company').text());
 			var streetAddress 	= jQuery.trim(jQuery(this).find('.myparcelcom-pudo-location-info .myparcelcom-pudo-location-details:eq(0)').text());
 			var city 			= jQuery.trim(jQuery(this).find('.myparcelcom-pudo-location-info .myparcelcom-pudo-location-details:eq(1)').text());
@@ -14,9 +13,8 @@ jQuery(document).on('click','.different_delivery',function(){
 			jQuery('#ship-to-different-address-checkbox').attr('checked',true);
 			jQuery('.shipping_address').show();
 			jQuery("#shipping_country option:selected").removeAttr("selected");
-
 			jQuery('#shipping_country option[value="'+countryCode+'"]').attr('selected','selected');
-			
+
 			var countryText = jQuery('#shipping_country option:selected').text();
 
 			jQuery('#select2-shipping_country-container').text(countryText);
@@ -27,10 +25,8 @@ jQuery(document).on('click','.different_delivery',function(){
 			jQuery('#shipping_city').val(city);
 			jQuery('#shipping_postcode').val(postalCode);
 
-            
 		}
 
 	});
-	
 
 });

--- a/includes/common/common-functions.php
+++ b/includes/common/common-functions.php
@@ -6,7 +6,6 @@ use MyParcelCom\ApiSdk\Resources\Shipment;
 use MyParcelCom\ApiSdk\Resources\ShipmentItem;
 use MyParcelCom\ApiSdk\Resources\File;
 use MyParcelCom\ApiSdk\LabelCombiner;
-use MyParcelCom\ApiSdk\Resources\Interfaces\FileInterface;
 use MyParcelCom\ApiSdk\LabelCombinerInterface;
 
 /**
@@ -621,7 +620,6 @@ function registerMyParcelWebHook($accessToken)
                         ],
                     ],
                 ],
-
             ],
     ];
     $dataString      = json_encode($data);

--- a/includes/common/myparcel-constant.php
+++ b/includes/common/myparcel-constant.php
@@ -1,5 +1,5 @@
 <?php
-define('MYPARCEL_PLUGIN_VERSION', '2.0.2');
+define('MYPARCEL_PLUGIN_VERSION', '2.0.3');
 define('ERROR_MESSAGE_CREDENTIAL', 'Incorrect client id or secret.');
 define('MYPARCEL_METHOD', 'myparcel');
 define('EXPORT_MYPARCEL_ORDER_TEXT', 'export_myparcel_order');

--- a/includes/myparcel-api.php
+++ b/includes/myparcel-api.php
@@ -37,6 +37,7 @@ class MyParcelApi
                 );
                 $authenticator->getAuthorizationHeader(true);
                 $api->authenticate($authenticator);
+                $api->clearCache(); // Fix issue caused by the MyParcel.com SDK caching resources like shops for a week.
 
                 return $api;
             } catch (AuthenticationException $e) {

--- a/includes/myparcel-hooks.php
+++ b/includes/myparcel-hooks.php
@@ -6,7 +6,6 @@ use MyParcelCom\ApiSdk\Resources\Address;
 use MyParcelCom\ApiSdk\Resources\Customs;
 use MyParcelCom\ApiSdk\Resources\Shipment;
 use MyParcelCom\ApiSdk\Resources\Interfaces\PhysicalPropertiesInterface;
-use MyParcelCom\ApiSdk\Http\Exceptions\RequestException;
 
 function myparcelExceptionRedirection()
 {
@@ -17,7 +16,6 @@ function myparcelExceptionRedirection()
 }
 
 /**
- *
  * @return void
  */
 function addFrontEndJs()
@@ -288,10 +286,6 @@ function getPartialShippingQuantity($orderId): array
 
 /**
  * Logic for exporting order to MyParcel.com
- *
- * @param array $orderId
- *
- * @return $shipmentId
  **/
 function createPartialOrderShipment($orderId, $totalWeight, $shippedItems = [])
 {
@@ -351,7 +345,6 @@ function createPartialOrderShipment($orderId, $totalWeight, $shippedItems = [])
 
     $getAuth  = new MyParcelApi();
     $api      = $getAuth->apiAuthentication();
-    $services = $api->getServices($shipment);
     // Have the SDK determine the cheapest service and post the shipment to the MyParcel.com API.
     $createdShipment = $api->createShipment($shipment);
     $shipmentId      = $createdShipment->getId();
@@ -360,11 +353,7 @@ function createPartialOrderShipment($orderId, $totalWeight, $shippedItems = [])
     return $shipmentId;
 }
 
-
 /**
- * @param Shipment $shipment
- * @param string   $when
- *
  * @return mixed
  **/
 function setShipmentRegister($shipmentId)
@@ -375,22 +364,7 @@ function setShipmentRegister($shipmentId)
     $shipment->setRegisterAt(new \DateTime());
     $updateShipmentResp = $api->updateShipment($shipment);
 
-    return;
-}
-
-
-/**
- * @param Shipment $shipment
- * @param string   $when
- *
- * @return mixed
- **/
-function setRegisterAt($shipment, $when = 'now')
-{
-    $api = MyParcelComApi::getSingleton();
-    $shipment->setRegisterAt($when);
-
-    return $api->updateShipment($shipment);
+    return $updateShipmentResp;
 }
 
 /**

--- a/includes/myparcel-settings.php
+++ b/includes/myparcel-settings.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
 /**
- *
  * @return void
  */
 function settingPageJsCss()

--- a/includes/myparcel-shipment-hooks.php
+++ b/includes/myparcel-shipment-hooks.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
 /**
- *
  * @return void
  */
 function adminLoadJsCss()

--- a/woocommerce-connect-myparcel.php
+++ b/woocommerce-connect-myparcel.php
@@ -3,7 +3,7 @@
  * Plugin Name: MyParcel.com
  * Plugin URI:  https://www.myparcel.com
  * Description: This plugin enables you to choose MyParcel.com shipping methods on WooCommerce.
- * Version: 2.0.2
+ * Version: 2.0.3
  * Author: MyParcel.com
  * Requires at least:
  * Tested up to:
@@ -28,7 +28,7 @@ if (!defined('MY_PARCEL_PLUGIN_NAME')) {
 $errorMessage = '';
 $ver = (float)phpversion();
 $errorVersionMessage ='<div class="notice notice-error is-dismissible">
-            <p>'.MY_PARCEL_PLUGIN_NAME.' Supports php 7.1 and higher vesion .</p>
+            <p>'.MY_PARCEL_PLUGIN_NAME.' Supports php 7.1 and higher.</p>
         </div>';
 
 if (!(in_array('woocommerce/woocommerce.php', apply_filters('active_plugins', get_option('active_plugins'))))) {


### PR DESCRIPTION
A plugin user ran into the following error after switching from sandbox to production:
```
Call to a member function getSenderAddress() on null
```
I believe this is due to a caching issue where the SDK `getShops()` is using `self::TTL_WEEK` by default.
This could result in [getSelectedShop()](https://github.com/MyParcelCOM/woo-plugin/blob/develop/includes/common/common-functions.php#L1044) (see code) to not match the shop ID from the config and return `null`.
If we flush the SDK cache upon loading WooCommerce, this should no longer be a problem.

I also removed some dead code and empty lines.