### PR TITLE
🐛 Sku should always be a string

### DIFF
--- a/includes/common/common-functions.php
+++ b/includes/common/common-functions.php
@@ -44,7 +44,7 @@ function getShipmentItems($orderId, $currency, $originCountryCode)
 
     foreach ($items as $item) {
         $product = $item->get_product();
-        $sku = $product->get_sku() ?: $product->get_id();
+        $sku = $product->get_sku() ?: (string) $product->get_id();
         $imageUrl = $product->get_image_id() ? wp_get_attachment_image_url($product->get_image_id(), 'medium') : null;
         $itemValue = (int) round(floatval($product->get_price()) * 100);
         $itemWeight = $product->get_weight() ? (int) round(floatval($product->get_weight()) * 1000) : null;

--- a/includes/common/myparcel-constant.php
+++ b/includes/common/myparcel-constant.php
@@ -1,6 +1,6 @@
 <?php
 
-define('MYPARCEL_PLUGIN_VERSION', '2.1.5');
+define('MYPARCEL_PLUGIN_VERSION', '2.1.6');
 define('SHIPMENT_PLUGIN_NOTICE', 'alive');
 define('GET_META_MYPARCEL_SHIPMENT_KEY', 'myparcel_shipment_key');
 define('GET_META_SHIPMENT_TRACKING_KEY', 'shipment_track_key');

--- a/woocommerce-connect-myparcel.php
+++ b/woocommerce-connect-myparcel.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * Plugin Name: MyParcel.com
  * Plugin URI: https://myparcel-com.odoo.com/en/woocommerce
  * Description: This plugin enables you to export WooCommerce orders to MyParcel.com.
- * Version: 2.1.5
+ * Version: 2.1.6
  * Author: MyParcel.com
  * Author URI: https://www.myparcel.com
  * Requires at least:


### PR DESCRIPTION
This bug is only experienced when products do not have an SKU.
The fallback to `$product->get_id()` returns an `int` while our SKU is expected to be a string, so this needs to be typecasted.