### PR TITLE
🪳 Print labels from HPOS order overview

### DIFF
--- a/assets/admin/js/admin-orders.js
+++ b/assets/admin/js/admin-orders.js
@@ -1,12 +1,4 @@
 jQuery(function ($) {
-  // Make mass action open modal and cancel form submit.
-  $('#doaction').click(function (e) {
-    if (jQuery('#bulk-action-selector-top').val() === 'print_label_shipment') {
-      labelModalDialog.dialog('open')
-      e.preventDefault()
-    }
-  })
-
   var labelModalDialog = jQuery('#labelModal').dialog({
     autoOpen: false,
     closeText: '',
@@ -15,8 +7,16 @@ jQuery(function ($) {
     width: 400,
   })
 
-  var selectVal = $('#printer-orientation input[name=\'selectorientation\']:checked').val()
-  $('#printer-orientation input[name=\'selectorientation\']').click(function () {
+  // Make mass action open modal and cancel form submit.
+  $('#doaction').click(function (e) {
+    if (jQuery('#bulk-action-selector-top').val() === 'print_label_shipment') {
+      labelModalDialog.dialog('open')
+      e.preventDefault()
+    }
+  })
+
+  var selectVal = $('#printer-orientation input[name="selectorientation"]:checked').val()
+  $('#printer-orientation input[name="selectorientation"]').click(function () {
     selectVal = $(this).val()
     $('div.cntnr').hide()
     $('#orientation' + selectVal).show()
@@ -27,8 +27,8 @@ jQuery(function ($) {
     $('#loadingmessage').show()
 
     // Retrieve selected orders (non-HPOS)
-    $('.wp-list-table #the-list tr input[name=\'post[]\']:checked').map(function () {
-      if ($('.wp-list-table #the-list tr input[name=\'post[]\']').is(':checked')) {
+    $('.wp-list-table #the-list tr input[name="post[]"]:checked').map(function () {
+      if ($('.wp-list-table #the-list tr input[name="post[]"]').is(':checked')) {
         var idx = $.inArray($(this).val(), selected)
         if (idx == -1) {
           selected.push($(this).val())
@@ -39,11 +39,11 @@ jQuery(function ($) {
     })
 
     // Retrieve selected orders (HPOS)
-    $('.wp-list-table #the-list tr input[name=\'id[]\']:checked').map(function (index, element) {
+    $('.wp-list-table #the-list tr input[name="id[]"]:checked').map(function (index, element) {
       selected.push(element.value)
     })
 
-    var selectOrientation = $('input[name=\'radio\']:checked').val()
+    var selectOrientation = $('input[name="radio"]:checked').val()
     if (selectOrientation) {
       var data = {
         'action': 'myparcelcom_download_pdf',

--- a/assets/admin/js/admin-orders.js
+++ b/assets/admin/js/admin-orders.js
@@ -2,12 +2,12 @@ jQuery(function ($) {
   // Make mass action open modal and cancel form submit.
   $('#doaction').click(function (e) {
     if (jQuery('#bulk-action-selector-top').val() === 'print_label_shipment') {
-      jQuery('#labelModal').dialog('open')
+      labelModalDialog.dialog('open')
       e.preventDefault()
     }
   })
 
-  jQuery('#labelModal').dialog({
+  var labelModalDialog = jQuery('#labelModal').dialog({
     autoOpen: false,
     closeText: '',
     modal: true,
@@ -21,10 +21,12 @@ jQuery(function ($) {
     $('div.cntnr').hide()
     $('#orientation' + selectVal).show()
   })
-  $('#download-pdf').click(function (e) {
+  labelModalDialog.find('#download-pdf').click(function (e) {
     var selected = []
     e.preventDefault()
     $('#loadingmessage').show()
+
+    // Retrieve selected orders (non-HPOS)
     $('.wp-list-table #the-list tr input[name=\'post[]\']:checked').map(function () {
       if ($('.wp-list-table #the-list tr input[name=\'post[]\']').is(':checked')) {
         var idx = $.inArray($(this).val(), selected)
@@ -35,6 +37,12 @@ jQuery(function ($) {
         selected.splice($(this).val())
       }
     })
+
+    // Retrieve selected orders (HPOS)
+    $('.wp-list-table #the-list tr input[name=\'id[]\']:checked').map(function (index, element) {
+      selected.push(element.value)
+    })
+
     var selectOrientation = $('input[name=\'radio\']:checked').val()
     if (selectOrientation) {
       var data = {
@@ -57,7 +65,7 @@ jQuery(function ($) {
           downloadLink.download = fileName
           downloadLink.click()
           $('#loadingmessage').hide()
-          $('#labelModal').dialog('close')
+          labelModalDialog.dialog('close')
         }
       })
     }

--- a/includes/common/common-functions.php
+++ b/includes/common/common-functions.php
@@ -46,7 +46,6 @@ function getTotalWeightByOrderID(int $orderId): float
  */
 function getShipmentItems($orderId, $currency, $originCountryCode): array
 {
-    $order = wc_get_order($orderId);
     $items = getOrderItemsByOrderId($orderId);
     $shipmentItems = [];
 
@@ -80,7 +79,8 @@ function getShipmentItems($orderId, $currency, $originCountryCode): array
 function admin_order_list_top_bar_button(string $which): void
 {
     global $typenow;
-    if ('shop_order' === $typenow && 'top' === $which) {
+
+    if (('shop_order' === $typenow && 'top' === $which) || $which === 'shop_order') {
         ?>
       <div id="labelModal" tabindex="-1" aria-hidden="true" style="display:none">
         <div class="modal-content">
@@ -140,7 +140,8 @@ function admin_order_list_top_bar_button(string $which): void
     }
 }
 
-add_action('manage_posts_extra_tablenav', 'admin_order_list_top_bar_button', 20, 1);
+add_action('manage_posts_extra_tablenav', 'admin_order_list_top_bar_button', 20);
+add_action('woocommerce_order_list_table_extra_tablenav', 'admin_order_list_top_bar_button', 20); // HPOS
 
 /**
  * Handle the "print_label_shipment" action after the label dialog is shown to select the print position.
@@ -164,7 +165,7 @@ function downloadPdf(): void
 
     foreach ($orderIds as $orderId) {
         $order = wc_get_order($orderId);
-        $shipmentId =  $order->get_meta(MYPARCEL_SHIPMENT_ID);
+        $shipmentId = $order->get_meta(MYPARCEL_SHIPMENT_ID);
 
         // If no shipment ID is found, we check the legacy meta, which is used by our v2.x plugin.
         if (empty($shipmentId)) {

--- a/woocommerce-connect-myparcel.php
+++ b/woocommerce-connect-myparcel.php
@@ -23,13 +23,6 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly.
 }
 
-// Declare HPOS compatibility.
-add_action('before_woocommerce_init', function() {
-    if (class_exists(FeaturesUtil::class)) {
-        FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__);
-    }
-});
-
 require_once dirname(__FILE__) . '/vendor/autoload.php';
 require_once dirname(__FILE__) . '/includes/myparcel-api.php';
 require_once dirname(__FILE__) . '/includes/common/myparcel-constant.php';
@@ -37,3 +30,24 @@ require_once dirname(__FILE__) . '/includes/common/common-functions.php';
 require_once dirname(__FILE__) . '/includes/myparcel-hooks.php';
 require_once dirname(__FILE__) . '/includes/myparcel-shipment-hooks.php';
 require_once dirname(__FILE__) . '/includes/myparcel-settings.php';
+
+// Declare HPOS compatibility.
+add_action('before_woocommerce_init', function() {
+    if (class_exists(FeaturesUtil::class)) {
+        FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__);
+    }
+});
+
+// Declare the custom order meta.
+add_action('woocommerce_init', function () {
+    register_post_meta('shop_order', MYPARCEL_SHIPMENT_ID, [
+        'type'         => 'string',
+        'single'       => true,
+        'show_in_rest' => false,
+    ]);
+    register_post_meta('shop_order', MYPARCEL_SHIPMENT_DATA, [
+        'type'         => 'string',
+        'single'       => true,
+        'show_in_rest' => false,
+    ]);
+});


### PR DESCRIPTION
The list of selected order IDs was empty, because the HPOS order overview renders checkboxes with
`name="id[]"` instead of `name="post[]"`

This PR also includes a dialog fix, probably needed by a newer version of jQuery dialog. We avoid the following error:
`cannot call methods on dialog prior to initialization; attempted to call method 'open'`